### PR TITLE
added matrix support to ecospat.boyce

### DIFF
--- a/R/ecospat.boyce.R
+++ b/R/ecospat.boyce.R
@@ -32,7 +32,7 @@ boycei <- function(interval, obs, fit) {
 
 ecospat.boyce <- function(fit, obs, nclass = 0, window.w = "default", res = 100, PEplot = TRUE) {
   if (class(fit) == "RasterLayer") {
-    if (class(obs) == "data.frame") {
+    if (class(obs) == "data.frame" | class(obs) == "matrix") {
       obs <- extract(fit, obs)
     }
     fit <- getValues(fit)


### PR DESCRIPTION
I realized that if you input a matrix of coordinates into ecospat.boyce, you get erroneous results, as the function uses the coordinates instead of suitability values for the calculation. I added matrix support to the function (small fix).